### PR TITLE
[FIX] Add missing view id that prevents the project from building.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -7,7 +7,7 @@ Version 4
    - No longer uses Apache HTTP
    - No longer relies on removed Notification methods
 * Changed to refer to Google Play
-* Notifications now rely on support library.
+* Notifications now rely on support-v7 22.+ and support-v4 22.0.+.
 
 Version 3
 * Directory structure corrected in distribution. No code changes.

--- a/apkx_library/res/layout-v11/status_bar_ongoing_event_progress_bar.xml
+++ b/apkx_library/res/layout-v11/status_bar_ongoing_event_progress_bar.xml
@@ -42,6 +42,7 @@
     </FrameLayout>
 
     <RelativeLayout
+        android:id="@+id/progress_bar_frame"
         android:layout_width="0dip"
         android:layout_height="match_parent"
         android:layout_gravity="center_vertical"


### PR DESCRIPTION
After long days and nights trying to figure out how to get this to work we finally arrived to a working solution.

 Very important for everyone reading, the tutorial [here](https://developer.android.com/google/play/expansion-files.html#Preparing) is *outdated*. And getting V4 of this library through Android SDK Manager is **impossible**. As of 2017-03-25.

This is what needs to be fixed in the tutorial:

> Item 5 says go to “play_apk_expansion” folder but for item 2.2 (android update project) uses “market_licensing” which seems to be the new folder.

> The other thing is that the “android update project” command is deprecated as of build-tools 25. But tools/bin/sdkmanager - -list shows truncated packages to 80 columns which makes it impossible to specify which package we want :(

> Finally when going to the file system (market_licensing) and inspecting the README from that location, we see that it’s version 3 we have, but the SDK Manager says the latest is version 1. What we actually expect is version 4… 

We also tried installing it from GitHub manually from here. Mostly because we lack a sample build.gradle for those. The dependencies needed are the ones now being added to the readme.

Moreover, when running the legacy “android” command we saw version 3 in the list but is unable to download 4.  The difference is that her “SDK Download sites” Url end in repository.xml instead of repository2-1.xml like ours do… 

Looking at the raw download sites we see version mismatches for the UI in other non-popular tools, so it seems that those repositories are in some bad state. We also tried a fresh copy of Android Studio and downloaded any possible package and still didn’t get version 4 of the library. We also used “force http” checkbox as the internet suggested.